### PR TITLE
Replace getTileLocation to Tile and change context when pointer is drawn

### DIFF
--- a/src/ModEntry.cs
+++ b/src/ModEntry.cs
@@ -64,9 +64,9 @@ namespace ForagePointers
 
         private void OnHudRendering(object sender, RenderingHudEventArgs e)
         {
-            if (Context.IsWorldReady && shouldDraw)
+            if (Context.IsPlayerFree && shouldDraw) //Changing Context.IsWorldReady to Context.IsPlayerFree to avoid drawing pointer during event and when menu opened
             {
-                var loc = Game1.player.getTileLocation();
+                var loc = Game1.player.Tile; //getTileLocation removed
                 var viewDist = Math.Pow(MinimumViewDistance + (Game1.player.ForagingLevel / ScaleEveryNLevels * ViewScalingFactor), 2);
 
                 foreach (var v in Game1.currentLocation.objects.Pairs)


### PR DESCRIPTION
Hi Bpendragon,
Following the GettingStarted page on wiki, I tried updating Forage Pointers to 1.6 and seems like changing the target framework to Net 6, API in manifest, and 1 line managed to get the mod working. There are warnings remain in visual studio, but I don't have the know how what to do with them... I also changed the context so that the Pointer doesn't blink during cutscenes.

If you have the time to update, would you consider adding [Generic Mod Config Menu](https://github.com/spacechase0/StardewValleyMods/tree/develop/GenericModConfigMenu) support? I tried but the attempt doesn't go anywhere. 

Thank you!